### PR TITLE
Solve #1; installation failure with inline function

### DIFF
--- a/configure
+++ b/configure
@@ -3830,6 +3830,8 @@ fi
 
 
 
+
+
 ac_config_headers="$ac_config_headers src/config.h"
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,11 @@ fi
 
 
 dnl #####
+dnl ## To handle inline functions in some compilers
+dnl ## From lines 481 in configure.ac from GSL
+AH_TEMPLATE([HIDE_INLINE_STATIC],[Define if you need to hide the static definitions of inline functions])
+
+dnl #####
 dnl ## To define GSL_COERCE_DBL() in config.h
 dnl ## From lines 508-526 in configure.ac from GSL
 AH_BOTTOM([/* Define a rounding function which moves extended precision values

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -33,6 +33,9 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
+/* Define if you need to hide the static definitions of inline functions */
+#undef HIDE_INLINE_STATIC
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/src/gsl/build.h
+++ b/src/gsl/build.h
@@ -1,0 +1,42 @@
+// This file is taken from GSL version 2.8 and distributed as part of qfratio
+// with modification, in accordance with the GNU General Public License
+// version 3.  All modified lines are marked with comments.
+// - 2023 Junya Watanabe
+
+/* Compile subsequent inline functions as static functions */
+
+#ifdef __GSL_BUILD_H__
+#error build.h must not be included multiple times
+#endif
+
+#define __GSL_BUILD_H__
+
+#ifdef COMPILE_INLINE_STATIC
+#ifndef HIDE_INLINE_STATIC  /* skip if inline functions are hidden */
+
+#undef __GSL_INLINE_H__
+#define __GSL_INLINE_H__  /* first, ignore the gsl_inline.h header file */
+
+#undef INLINE_DECL
+#define INLINE_DECL       /* disable inline in declarations */
+
+#undef INLINE_FUN
+#define INLINE_FUN        /* disable inline in definitions */
+
+#ifndef HAVE_INLINE       /* enable compilation of definitions in .h files */
+#define HAVE_INLINE
+#endif     
+
+/* Compile range checking code for inline functions used in the library */
+#undef GSL_RANGE_CHECK
+#define GSL_RANGE_CHECK 1
+
+/* Use the global variable gsl_check_range to enable/disable range checking at
+   runtime */
+#undef GSL_RANGE_COND
+#define GSL_RANGE_COND(x) (gsl_check_range && (x))
+
+#endif
+#else 
+#error must be called with COMPILE_INLINE_STATIC
+#endif

--- a/src/gsl/poly/eval.c
+++ b/src/gsl/poly/eval.c
@@ -1,0 +1,32 @@
+// This file is taken from GSL version 2.8 and distributed as part of qfratio
+// with modification, in accordance with the GNU General Public License
+// version 3.  All modified lines are marked with comments.
+// - 2023 Junya Watanabe
+
+/* poly/eval.c
+ * 
+ * Copyright (C) 1996, 1997, 1998, 1999, 2000 Gerard Jungman
+ * Complex functions Copyright (C) 2007 Frank Reininghaus
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or (at
+ * your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <config.h>
+
+/* Compile all the inline functions */
+
+#define COMPILE_INLINE_STATIC
+#include "../build.h" // edited for qfratio
+#include "gsl_poly.h" // edited for qfratio

--- a/src/scripts/SOURCES_GSL.mkf
+++ b/src/scripts/SOURCES_GSL.mkf
@@ -14,6 +14,7 @@ SOURCES_GSL = \
     gsl/integration/set_initial.c \
     gsl/integration/util.c \
     gsl/integration/workspace.c \
+    gsl/poly/eval.c \
     gsl/roots/brent.c \
     gsl/roots/convergence.c \
     gsl/roots/fsolver.c \

--- a/src/scripts/gsl_files.mkf
+++ b/src/scripts/gsl_files.mkf
@@ -15,6 +15,7 @@ integration/reset.c
 integration/set_initial.c
 integration/util.c
 integration/workspace.c
+poly/eval.c
 poly/gsl_poly.h
 roots/brent.c
 roots/convergence.c
@@ -72,6 +73,7 @@ sys/gsl_sys.h
 sys/coerce.c
 sys/fdiv.c
 sys/infnan.c
+build.h
 gsl_inline.h
 gsl_machine.h
 gsl_math.h

--- a/src/scripts/process_gsl.sh
+++ b/src/scripts/process_gsl.sh
@@ -14,6 +14,7 @@ localize_header_inclusion() {
     do
         sed -i -E "s|#include *<gsl/$HEADER>|#include \"$HEADER\" // edited for qfratio|"    $INDIR/*.h
         sed -i -E "s|#include *<gsl/$HEADER>|#include \"../$HEADER\" // edited for qfratio|" $INDIR/*/*
+        sed -i -E "s|#include *\"$HEADER\"|#include \"../$HEADER\" // edited for qfratio|"    $INDIR/*/*
     done
     
     ## Then loop across subdirectories


### PR DESCRIPTION
Solve #1, installation failure on macOS 10.6 (powerpc), gcc 13.3.0, R 4.4.1, due to `Symbol not found: _gsl_poly_eval`.
The inline function `gsl_poly_eval()` was not treated in the portable, robust way that GSL does, causing a problem in certain platforms that the package had not previously been tested with.
Solved by adding build.h and poly/eval.c from GSL, which appropriately handle this matter.